### PR TITLE
Fix classification and highlighting of filter lists

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Macros
+[attr]adb   linguist-language=Adblock linguist-detectable
+[attr]hosts linguist-language=Hosts   linguist-generated
+
+# Fix highlighting and classification of files on GitHub
+filters/** adb
+hosts/** adb
+test/* adb
+hosts.txt hosts
+hosts_blokada.txt hosts
+it adb
+it0 adb
+*.md -adb -hosts


### PR DESCRIPTION
This pull-request fixes the syntax highlighting and language classification of this project's filter-list files, which are currently unrecognised by GitHub. It achieves this by [using `.gitattributes`](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#using-gitattributes) to specify the languages of files whose filenames and/or extensions aren't registered with [GitHub Linguist](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml).

Note that due to caching issues, merging this may not update the project's classification immediately; pushing a follow-up change will fix it.